### PR TITLE
test_mic: change default device names for mic and speaker.

### DIFF
--- a/src/test_mic.sh
+++ b/src/test_mic.sh
@@ -45,8 +45,8 @@ Usage: $0 options
 
 OPTIONS:
 -h         Show this message
--i  <arg>  PCM input device name e.g. -i mic
--o  <arg>  PCM output device name e.g. -o hw:0,2
+-i  <arg>  PCM input device name e.g. -i default
+-o  <arg>  PCM output device name e.g. -o hw:0,2/default
 -w         Wait for user input on PASS/FAIL
 -c  <arg>  Seconds to record and play, default 30 secs, pass 0 for continuous mode
 -v         Verbose


### PR DESCRIPTION
As /ets/asound.conf is removed and support for pistachio-card
is added in alsa-lib, name of the devices is changed as
"default" according to configuration.

Signed-off-by: Manohar Narkhede <Manohar.Narkhede@imgtec.com>
This connects to CreatorDev/openwrt#25